### PR TITLE
Add {unordered} option for matching arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,17 +4,21 @@ function isArguments (obj) {
   return Object.prototype.toString.call(obj) === '[object Arguments]'
 }
 
+function isArray(obj) {
+  return Object.prototype.toString.call(obj) === '[object Array]'
+}
+
 module.exports = match
 
-function match (obj, pattern) {
-  return match_(obj, pattern, [], [])
+function match (obj, pattern, opts) {
+  return match_(obj, pattern, [], [], opts || {})
 }
 
 /* istanbul ignore next */
 var log = (/\btmatch\b/.test(process.env.NODE_DEBUG || '')) ?
   console.error : function () {}
 
-function match_ (obj, pattern, ca, cb) {
+function match_ (obj, pattern, ca, cb, opts) {
   log('TMATCH', typeof obj, pattern)
   if (obj == pattern) {
     log('TMATCH same object or simple value, or problem')
@@ -58,7 +62,7 @@ function match_ (obj, pattern, ca, cb) {
   } else if (isArguments(obj) || isArguments(pattern)) {
     log('TMATCH arguments test')
     var slice = Array.prototype.slice
-    return match_(slice.call(obj), slice.call(pattern), ca, cb)
+    return match_(slice.call(obj), slice.call(pattern), ca, cb, opts)
 
   } else if (pattern === Buffer) {
     log('TMATCH Buffer ctor')
@@ -138,8 +142,15 @@ function match_ (obj, pattern, ca, cb) {
     var key
     for (var l = kpat.length - 1; l >= 0; l--) {
       key = kpat[l]
-      log('  TMATCH test obj[%j]', key, obj[key], pattern[key])
-      if (!match_(obj[key], pattern[key], ca, cb)) return false
+      if (opts.unordered && isArray(obj)) {
+        log('  TMATCH test unordered array')
+        if (!obj.find(function(v) {
+          return match_(v, pattern[key], ca, cb, opts)
+        })) return false
+      } else {
+        log('  TMATCH test obj[%j]', key, obj[key], pattern[key])
+        if (!match_(obj[key], pattern[key], ca, cb, opts)) return false
+      }
     }
 
     ca.pop()

--- a/test/deep.js
+++ b/test/deep.js
@@ -87,6 +87,14 @@ test("different arrays don't match", function (t) {
   t.end()
 })
 
+test("arrays match when unordered", function (t) {
+  t.ok(match([1, 2, 3], [3, 2, 1], {unordered: true}))
+  t.ok(match([5, 6, 2, 1, 3, 4], [1, 2, 4], {unordered: true}))
+  t.ok(match([[5, 5], [1, 2]], [[2, 1]], {unordered: true}))
+  t.ok(match([{x: 0, y: 0}, {x: 5, y: 5}], [{x: 5, y: 5}], {unordered: true}))
+  t.end()
+})
+
 test('empty arrays match', function (t) {
   t.ok(match([], []))
   t.ok(match({ x: [] }, { x: [] }))
@@ -156,7 +164,7 @@ test("tmatch shouldn't care about key order (but still might) and types", functi
 
 test("match shouldn't blow up on circular data structures", function (t) {
   var x1 = { z: 4 }
-  var y1 = { x: x1 }
+  var y1 = { x: x1  }
   x1.y = y1
 
   var x2 = { z: 4 }


### PR DESCRIPTION
I've had this requirement for two use cases:
1. Large lists where I want to describe _some_ important elements which should exist but not have to describe every element in order to fill the keys.
2. Data sets where order is non-deterministic. Particularly when dealing with lots of async data.

All of this compounded with the desire to keep my assertions very succinct within a single pattern value rather than having half pattern matching and half targeted assertions in my test code.

Understandably this may not be something which is wanted in this library but if not would you mind if I made the npm package with name `tmatch-unordered` and keep it as a fork? :)
