### PR TITLE
always compare against stringified object when pattern is RegExp

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ Copied from the source, here are the details of `tmatch`'s algorithm:
     fields all match.
 15. If the object is a buffer, and the pattern is also a buffer, then
     return true if they contain the same bytes.
-16. At this point, both object and pattern are object type values, so
+16. If the pattern is a RegExp, then return true if `pattern.test(object)`.
+17. At this point, both object and pattern are object type values, so
     compare their keys:
     1. Get list of all iterable keys in pattern and object.  If both
        are zero (two empty objects), return true.

--- a/README.md
+++ b/README.md
@@ -46,34 +46,34 @@ Copied from the source, here are the details of `tmatch`'s algorithm:
    true if `pattern.test(object)`.
 3. If the object is a string and the pattern is a non-empty string,
    then return true if the string occurs within the object.
-5. If the object and the pattern are both Date objects, then return
+4. If the object and the pattern are both Date objects, then return
    true if they represent the same date.
-6. If the object is a Date object, and the pattern is a string, then
+5. If the object is a Date object, and the pattern is a string, then
    return true if the pattern is parseable as a date that is the same
    date as the object.
-7. If the object is an `arguments` object, or the pattern is an
+6. If the object is an `arguments` object, or the pattern is an
    `arguments` object, then cast them to arrays and compare their
    contents.
-8. If the pattern is the `Buffer` constructor, then return true if the
+7. If the pattern is the `Buffer` constructor, then return true if the
    object is a Buffer.
-9. If the pattern is the `Function` constructor, then return true if
+8. If the pattern is the `Function` constructor, then return true if
    the object is a function.
-10. If the pattern is the String constructor, then return true if the
-    pattern is a string.
-11. If the pattern is the Boolean constructor, then return true if the
+9. If the pattern is the String constructor, then return true if the
+   pattern is a string.
+10. If the pattern is the Boolean constructor, then return true if the
     pattern is a boolean.
-12. If the pattern is the Array constructor, then return true if the
+11. If the pattern is the Array constructor, then return true if the
     pattern is an array.
-13. If the pattern is any function, and then object is an object, then
+12. If the pattern is any function, and then object is an object, then
     return true if the object is an `instanceof` the pattern.
-14. At this point, if the object or the pattern are not objects, then
+13. At this point, if the object or the pattern are not objects, then
     return false (because they would have matched earlier).
-15. If the object is a RegExp and the pattern is also a RegExp, return
+14. If the object is a RegExp and the pattern is also a RegExp, return
     true if their source, global, multiline, lastIndex, and ignoreCase
     fields all match.
-16. If the object is a buffer, and the pattern is also a buffer, then
+15. If the object is a buffer, and the pattern is also a buffer, then
     return true if they contain the same bytes.
-17. At this point, both object and pattern are object type values, so
+16. At this point, both object and pattern are object type values, so
     compare their keys:
     1. Get list of all iterable keys in pattern and object.  If both
        are zero (two empty objects), return true.

--- a/index.js
+++ b/index.js
@@ -115,6 +115,9 @@ function match_ (obj, pattern, ca, cb) {
 
       return true
     }
+  } else if (pattern instanceof RegExp) {
+    log('TMATCH any~=regexp test')
+    return pattern.test(String(obj))
 
   } else {
     // both are objects.  interesting case!

--- a/test/deep.js
+++ b/test/deep.js
@@ -276,3 +276,20 @@ test('js WAT! array/string stuff', function (t) {
   t.ok(match(1, '1'))
   t.end()
 })
+
+test('regexps match objects according to their string representation', function (t) {
+  t.ok(match(['asdf'], /asdf/))
+  t.notOk(match(['asdf'], /hjkl/))
+
+  var err = new Error('foobar')
+
+  t.ok(match(err, /foobar/))
+  t.notOk(match(err, /asdfghjkl/))
+
+  var obj = { foobar: 'foobar' }
+
+  t.ok(match(obj, /object Object/))
+  t.notOk(match(obj, /asdfghjkl/))
+
+  t.end()
+})


### PR DESCRIPTION
When the pattern is a regular expression and the object has not
already been detected as a regular expression too, one can be almost
100 % certain that the user meant to compare the stringified version
of the left-hand side (e.g. for errors, arrays, etc.) against
the regular expression.

Previously, this would almost always pass silently in these simple
cases.

This is likely a **semver-major** change, both for `tmatch` and `tap`.

(side note: I was particularly confused when looking into this by the fact that node-tap.org itself [says](http://www.node-tap.org/asserts/#tthrowsfn-expectederror-message-extra) that `tap` uses `t.match(er, …)` for `t.throws`. I’d PR over there too, but I can’t seem to find the website repo, if there is any.)

/cc @isaacs 
